### PR TITLE
Middleware code implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # authmid
 Authentication middleware for signed requests, useful for webhook authentication verifying identities
+
+## Usage
+Create your custom authenticator that conforms to interface Authenticator
+so that you can custom lookup the secret, and headers and pass that into
+Middleware to wrap the next handler. For example, simply:
+```go
+func main() {
+	http.Handle("/", authmid.Middleware(&sampleAuthChecker{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Authenticated pong!")
+	})))
+
+	// Then run the server to receive traffic.
+}
+```
+
+Or for a more comprehensive end to end working example:
+
+```go
+func main() {
+	srv := httptest.NewServer(authmid.Middleware(&sampleAuthChecker{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		fmt.Fprintf(w, "Well authenticated, and here is your body: %s", body)
+	})))
+	defer srv.Close()
+
+	// The client will then authenticate like this
+	req := makeReq("POST", []byte(`{"name": "foo", "age": 99}`), authKey1)
+	req.URL, _ = url.Parse(srv.URL)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer res.Body.Close()
+	blob, _ := ioutil.ReadAll(res.Body)
+	fmt.Printf("response: %s\n", blob)
+}
+```

--- a/authmid.go
+++ b/authmid.go
@@ -1,0 +1,136 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authmid
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type Authenticator interface {
+	LookupSecret(apiKey string) ([]byte, error)
+	HeaderValues(hdr http.Header) (values, warnings []string, err error)
+	LookupAPIKey(hdr http.Header) (string, error)
+	Signature(hdr http.Header) (string, error)
+}
+
+var (
+	ErrSignatureMismatch = errors.New("invalid/mismatched signatures")
+)
+
+func Middleware(vf Authenticator, next http.Handler) http.Handler {
+	return &auther{verify: Checker(vf), next: next}
+}
+
+type auther struct {
+	verify func(*http.Request) error
+	next   http.Handler
+}
+
+var _ http.Handler = (*auther)(nil)
+
+func (a *auther) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := a.verify(r)
+	if err == nil {
+		// We can proceed, verification was successful.
+		a.next.ServeHTTP(w, r)
+		return
+	}
+
+	// Otherwise we've encountered an error
+	switch typ := err.(type) {
+	case CodedError:
+		http.Error(w, typ.Error(), typ.Code())
+	default:
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+}
+
+var errNilHeader = errors.New("expecting a non-nil header")
+
+func Checker(vf Authenticator) func(*http.Request) error {
+	return func(req *http.Request) error {
+		if req == nil || len(req.Header) == 0 {
+			return errNilHeader
+		}
+		wantSignature, err := vf.Signature(req.Header)
+		if err != nil {
+			return err
+		}
+		apiKey, err := vf.LookupAPIKey(req.Header)
+		if err != nil {
+			return err
+		}
+		apiSecret, err := vf.LookupSecret(apiKey)
+		if err != nil {
+			return err
+		}
+		rreq, body, err := slurpThenRecoverBody(req)
+		if err != nil {
+			return err
+		}
+		mac := hmac.New(sha256.New, apiSecret)
+		urlPath := rreq.URL.Path
+		if q := req.URL.Query(); len(q) > 0 {
+			urlPath += "?" + q.Encode()
+		}
+		headerValues, warnings, err := vf.HeaderValues(req.Header)
+		if err != nil {
+			return err
+		}
+		if len(warnings) > 0 {
+			// TODO: Figure out if to send this component in the
+			// response writer and when should the write be performed?
+		}
+		sigInput := append(headerValues, req.Method, urlPath, string(body))
+		_, _ = io.WriteString(mac, strings.Join(sigInput, ""))
+		gotSignature := fmt.Sprintf("%x", mac.Sum(nil))
+		if gotSignature != wantSignature {
+			return ErrSignatureMismatch
+		}
+		return nil
+	}
+}
+
+type CodedError interface {
+	Error() string
+	Code() int
+}
+
+func slurpThenRecoverBody(req *http.Request) (*http.Request, []byte, error) {
+	if req.Body == nil {
+		return req, nil, nil
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return req, nil, err
+	}
+	// Close the original body
+	_ = req.Body.Close()
+	prc, pwc := io.Pipe()
+	go func() {
+		defer pwc.Close()
+		pwc.Write(body)
+	}()
+	req.Body = prc
+	return req, body, nil
+}

--- a/authmid_test.go
+++ b/authmid_test.go
@@ -1,0 +1,239 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authmid_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orijtech/authmid"
+)
+
+func TestChecker(t *testing.T) {
+	tests := [...]struct {
+		Authenticator authmid.Authenticator
+		wantErr       bool
+
+		req, comparisonReq *http.Request
+	}{
+		0: {
+			req:           makeReq("POST", []byte(`{"name": "foo", "age": 99}`), authKey1),
+			Authenticator: &sampleAuthChecker{},
+			comparisonReq: makeReq("POST", []byte(`{"name": "foo", "age": 99}`), authKey1),
+		},
+		1: {
+			req:           makeReq("GET", nil, authKey2),
+			Authenticator: &sampleAuthChecker{},
+			comparisonReq: makeReq("GET", nil, authKey2),
+		},
+		2: {
+			req:           makeReq("GET", []byte(`{"name": "fiddler"}`), authKey1, "TEST-ACCESS-TIMESTAMP"),
+			Authenticator: &sampleAuthChecker{},
+			wantErr:       true, // "TEST-ACCESS-TIMESTAMP" was popped
+		},
+		3: {
+			req:           makeReq("POST", nil, authKey1, "TEST-ACCESS-TIMESTAMP"),
+			Authenticator: &sampleAuthChecker{},
+			wantErr:       true, // "TEST-ACCESS-TIMESTAMP" was popped
+		},
+
+		// Test with a custom method
+		4: {
+			req:           makeReq("FOMO", nil, authKey1),
+			Authenticator: &sampleAuthChecker{},
+			comparisonReq: makeReq("FOMO", nil, authKey1),
+		},
+	}
+
+	for i, tt := range tests {
+		checkFn := authmid.Checker(tt.Authenticator)
+		err := checkFn(tt.req)
+		gotErr := err != nil
+		if gotErr != tt.wantErr {
+			t.Errorf("#%d: gotErr=%v wantErr=%v; err:(%v)", i, gotErr, tt.wantErr, err)
+		}
+
+		// Now ensure that the dump of both requests is the same
+		gotDump, wantDump := dumpReqOut(tt.req), dumpReqOut(tt.comparisonReq)
+		if !tt.wantErr && !bytes.Equal(gotDump, wantDump) {
+			t.Errorf("#%d:\ngot: %q\nwant:%q\n", i, gotDump, wantDump)
+		}
+	}
+}
+
+type sampleAuthChecker struct{}
+
+var _ authmid.Authenticator = (*sampleAuthChecker)(nil)
+
+func (ca *sampleAuthChecker) HeaderValues(hdr http.Header) (values, warnings []string, err error) {
+	keys := []struct {
+		key      string
+		optional bool
+	}{
+		// {key: "TEST-VERSION", optional: true},
+		{key: "TEST-ACCESS-TIMESTAMP"},
+	}
+	var errsList []string
+	for _, st := range keys {
+		value, err := headerValueOrErr(hdr, st.key)
+		if err == nil {
+			values = append(values, value)
+			continue
+		}
+		if st.optional {
+			warnings = append(warnings, err.Error())
+		} else {
+			errsList = append(errsList, err.Error())
+		}
+	}
+	if len(errsList) > 0 {
+		return nil, warnings, errors.New(strings.Join(errsList, "\n"))
+	}
+	return values, warnings, nil
+}
+
+func (ca *sampleAuthChecker) LookupAPIKey(hdr http.Header) (string, error) {
+	return headerValueOrErr(hdr, "TEST-ACCESS-KEY")
+}
+
+var (
+	apiKey1 = "b9b60b63-e37b-4b45-9397-2c20433f4d53"
+	apiKey2 = "78e34d4c-7f6e-4c57-995d-224cd0296fd0"
+
+	bAPISecret1 = []byte("a41ce573-b848-40b2-9618-565f44133992")
+	bAPISecret2 = []byte("65d6829c-f9f9-45c5-9f9f-9646c0f129dc")
+
+	errUnknownAPIKey = errors.New("unknown API key")
+)
+
+func (ca *sampleAuthChecker) LookupSecret(apiKey string) ([]byte, error) {
+	switch apiKey {
+	case apiKey1:
+		return bAPISecret1, nil
+	case apiKey2:
+		return bAPISecret2, nil
+	default:
+		return nil, errUnknownAPIKey
+	}
+}
+
+func (ca *sampleAuthChecker) Signature(hdr http.Header) (string, error) {
+	return headerValueOrErr(hdr, "TEST-ACCESS-SIGN")
+}
+
+func headerValueOrErr(hdr http.Header, key string) (string, error) {
+	if value := hdr.Get(key); value != "" {
+		return value, nil
+	}
+	return "", fmt.Errorf("missing %q key", key)
+}
+
+func makeReq(method string, body []byte, aKey *authKey, hdrKeysToPop ...string) *http.Request {
+	var prc io.ReadCloser
+	if len(body) > 0 {
+		var pwc io.WriteCloser
+		prc, pwc = io.Pipe()
+		go func() {
+			defer pwc.Close()
+			pwc.Write(body)
+		}()
+	}
+
+	u, _ := url.Parse("https://orijtech.com/")
+	req := &http.Request{
+		Method: method,
+		Header: make(http.Header),
+		Body:   prc,
+		URL:    u,
+	}
+	aKey.signAndSetHeaders(req)
+
+	for _, hdrKey := range hdrKeysToPop {
+		req.Header.Del(hdrKey)
+	}
+	return req
+}
+
+func dumpReqOut(req *http.Request) []byte {
+	defer func() {
+		// Catch and ignore any panics
+		_ = recover()
+	}()
+	dump, _ := httputil.DumpRequestOut(req, true)
+	return dump
+}
+
+var (
+	authKey1 = &authKey{
+		key:    apiKey1,
+		secret: string(bAPISecret1),
+	}
+
+	authKey2 = &authKey{
+		key:    apiKey2,
+		secret: string(bAPISecret2),
+	}
+)
+
+type authKey struct {
+	secret, key string
+}
+
+func (aKey *authKey) signAndSetHeaders(req *http.Request) {
+	// Expecting headers:
+	// * TEST-ACCESS-KEY
+	// * TEST-ACCESS-SIGN:
+	//    + HMAC(timestamp + method + requestPath + body)
+	// * TEST-ACCESS-TIMESTAMP: Number of seconds since Unix Epoch of the request
+	timestamp := time.Now().Unix()
+	req.Header.Set("TEST-VERSION", "2017-06-07")
+	req.Header.Set("TEST-ACCESS-TIMESTAMP", fmt.Sprintf("%d", timestamp))
+	req.Header.Set("TEST-ACCESS-KEY", aKey.key)
+	req.Header.Set("TEST-ACCESS-SIGN", aKey.hmacSignature(req, timestamp))
+}
+
+func (aKey *authKey) hmacSignature(req *http.Request, timestampUnix int64) string {
+	var body []byte
+	if req.Body != nil {
+		body, _ = ioutil.ReadAll(req.Body)
+		// And we have to reconstruct the body now
+		prc, pwc := io.Pipe()
+		go func() {
+			defer pwc.Close()
+			pwc.Write(body)
+		}()
+		req.Body = prc
+	}
+
+	mac := hmac.New(sha256.New, []byte(aKey.secret))
+	urlPath := req.URL.Path
+	if q := req.URL.Query(); len(q) > 0 {
+		urlPath += "?" + q.Encode()
+	}
+	sig := fmt.Sprintf("%d%s%s%s", timestampUnix, req.Method, urlPath, body)
+	mac.Write([]byte(sig))
+	return fmt.Sprintf("%x", mac.Sum(nil))
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authmid_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/orijtech/authmid"
+)
+
+func Example_middleware() {
+	srv := httptest.NewServer(authmid.Middleware(&sampleAuthChecker{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		fmt.Fprintf(w, "Well authenticated, and here is your body: %s", body)
+	})))
+	defer srv.Close()
+
+	// The client will then authenticate like this
+	req := makeReq("POST", []byte(`{"name": "foo", "age": 99}`), authKey1)
+	req.URL, _ = url.Parse(srv.URL)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer res.Body.Close()
+	blob, _ := ioutil.ReadAll(res.Body)
+	fmt.Printf("response: %s\n", blob)
+}
+
+func Example_inPlainServer() {
+	http.Handle("/", authmid.Middleware(&sampleAuthChecker{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Authenticated pong!")
+	})))
+}


### PR DESCRIPTION
Implemented middleware that helps verify the authenticated of
signed requests where the client HMAC's
the body, custom headers and an ephemeral header/key then sends
the request to your server from where you can lookup the secret
and repeat the HMAC-ing and then compare the signatures.

Implementing the middleware is as simple as conforming to the
interface `Authenticator` and then passing in the next handler
to be invoked after authentication, for example the fully end to end
example below:

```go
package authmid_test

import (
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
	"net/http/httptest"
	"net/url"

	"github.com/orijtech/authmid"
)

func main() {
	srv := httptest.NewServer(authmid.Middleware(&sampleAuthChecker{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		body, _ := ioutil.ReadAll(r.Body)
		fmt.Fprintf(w, "Well authenticated, and here is your body: %s", body)
	})))
	defer srv.Close()

	// The client will then authenticate like this
	req := makeReq("POST", []byte(`{"name": "foo", "age": 99}`), authKey1)
	req.URL, _ = url.Parse(srv.URL)
	res, err := http.DefaultClient.Do(req)
	if err != nil {
		log.Fatal(err)
	}
	defer res.Body.Close()
	blob, _ := ioutil.ReadAll(res.Body)
	fmt.Printf("response: %s\n", blob)
}
```